### PR TITLE
fix: add missing app icon to tauri.conf.json for macOS bundle

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -27,6 +27,6 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": []
+    "icon": ["icons/icon.png"]
   }
 }


### PR DESCRIPTION
The icon array was empty, causing Tauri to fail when building the macOS
.app bundle and .dmg — both require at least one icon. Wire up the
existing icons/icon.png that was already in the repository.

https://claude.ai/code/session_01G3PTKR7KFzME85GqE28TcF